### PR TITLE
Include three-body interactions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+JLD2 = "0.6"
 KrylovKit = "0.10"
 MPSKit = "0.13"
 MPSKitModels = "0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HubbardTN"
 uuid = "31f8dd75-9f76-4da8-9aed-ce20a80dcd69"
 authors = ["Daan Vrancken"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(
         "Library" => "Functions.md",
         "Examples" => "Examples.md",
     ],
-    format = Documenter.HTML(inventory_version = "0.2.0"),
+    format = Documenter.HTML(inventory_version = "0.2.1"),
 )
 
 deploydocs(

--- a/src/HubbardTN.jl
+++ b/src/HubbardTN.jl
@@ -13,7 +13,7 @@ using MPSKit, MPSKitModels
 using TensorKit, KrylovKit
 using JLD2
 
-include("simulations.jl")
+include("models.jl")
 include("operators.jl")
 include("hamiltonian.jl")
 include("groundstate.jl")

--- a/src/models.jl
+++ b/src/models.jl
@@ -80,7 +80,7 @@ function hopping_matrix2dict(t::Union{Vector{T}, Matrix{T}}) where {T<:AbstractF
     for i in 1:bands
         for j in 1:(num_sites*bands)
             if isa(t, Matrix)
-                if t[i, j]!= 0.0
+                if t[i, j] != 0.0
                     hopping[(i, j)] = t[i, j]
                     hopping[(j, i)] = conj(t[i, j])
                 end

--- a/test/MultiBand.jl
+++ b/test/MultiBand.jl
@@ -14,8 +14,7 @@ tol = 1e-2
 @testset "ModelParams constructors" begin
     m1 = ModelParams([0.0 1.0; 1.0 0.0], Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
     m2 = ModelParams([0.0 1.0; 1.0 0.0], [5.0 0.0; 0.0 3.0])
-    m3 = ModelParams(2, Dict((1,2)=>1.0, (2,1)=>1.0, (1,1)=>0.0, (2,2)=>0.0), 
-                     Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
+    m3 = ModelParams(2, Dict((1,2)=>1.0, (2,1)=>1.0), Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
     @test m1.bands == m2.bands == m3.bands
     @test m1.t == m2.t == m3.t
     @test m1.U == m2.U == m3.U

--- a/test/ThreeBody.jl
+++ b/test/ThreeBody.jl
@@ -1,0 +1,28 @@
+println("
+################
+#  Three-Body  #
+################
+")
+
+tol = 1e-2
+
+
+############
+# One-band #
+############
+
+E_norm = -0.32384
+
+@testset "Three-body interaction terms" begin
+    symm = SymmetryConfig(U1Irrep, SU2Irrep, 2, (1,1))
+    t = [0.0, 1.0]
+    U = [6.0]
+    V = [2.0]
+    model = ModelParams(t, U, V)
+    calc = CalcConfig(symm, model)
+    gs = compute_groundstate(calc; tol=tol/10)
+    ψ₀ = gs["groundstate"]
+    H = gs["ham"]
+    E0 = expectation_value(ψ₀, H)/length(ψ₀)
+    @test real(E0) ≈ E_norm atol=tol
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,9 @@ ti = time()
     if GROUP == "ALL" || GROUP == "MultiBand"
         @time include("MultiBand.jl")
     end
-
+        if GROUP == "ALL" || GROUP == "ThreeBody"
+        @time include("ThreeBody.jl")
+    end
 end
 
 ti = time() - ti


### PR DESCRIPTION
This PR implements the possibility to add (simple) three-body interactions to the model.

The functionality of constructing models with exchange via matrices or vectors is deprecated.