### PR TITLE
Daan dev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ JLD2 = "0.6"
 KrylovKit = "0.10"
 MPSKit = "0.13"
 MPSKitModels = "0.4"
-TensorKit = "0.14, 0.15, 0.16"
+TensorKit = "0.15.3, 0.16"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # HubbardTN
 
-Contains code for constructing and solving general one-dimensional Hubbard models using matrix product states. The framework is built upon [MPSKit.jl](https://github.com/QuantumKitHub/MPSKit.jl) and [TensorKit.jl](https://github.com/jutho/TensorKit.jl). The functionalities include constructing a Hubbard Hamiltonian with arbitrary interactions represented by the tensor U<sub>ijkl</sub>, as well as enabling hopping and interactions beyond nearest neighbors. Additionally, the framework supports U(1) and SU(2) symmetries for both particle and spin symmetry. Check out the examples for concrete use-cases. More information can be found in the [docs](https://daanvrancken.github.io/HubbardTN.jl/stable).
+Contains code for constructing and solving general one-dimensional Hubbard models using matrix product states. The framework is built upon [MPSKit.jl](https://github.com/QuantumKitHub/MPSKit.jl) and [TensorKit.jl](https://github.com/jutho/TensorKit.jl). The functionalities include constructing a Hubbard Hamiltonian with arbitrary interactions represented by the tensor U<sub>ijkl</sub>, as well as enabling hopping and interactions beyond nearest neighbors. Additionally, the framework supports U(1) and SU(2) symmetries for both particle and spin symmetry. Check out the examples for concrete use-cases. More information can be found in the [documentation](https://daanvrancken.github.io/HubbardTN.jl/stable).
 
 To add this package to your Julia environment, do
 ```
 julia> using Pkg
-julia> Pkg.add(url="https://github.com/DaanVrancken/HubbardTN.jl")
+julia> Pkg.add("HubbardTN")
 ```
 after which it can be used by loading
 ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(
         "Library" => "Functions.md",
         "Examples" => "Examples.md",
     ],
-    format = Documenter.HTML(inventory_version = "0.3.0"),
+    format = Documenter.HTML(inventory_version = "0..0"),
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(
         "Library" => "Functions.md",
         "Examples" => "Examples.md",
     ],
-    format = Documenter.HTML(inventory_version = "0..0"),
+    format = Documenter.HTML(inventory_version = "0.3.0"),
 )
 
 deploydocs(

--- a/docs/src/Examples.md
+++ b/docs/src/Examples.md
@@ -26,7 +26,7 @@ symm = SymmetryConfig(particle_symmetry, spin_symmetry, cell_width, filling)
 t = [0.0, 1.0]   # [chemical_potential, nn_hopping, nnn_hopping, ...]
 U = [4.0]        # [on-site interaction, nn_interaction, ...]
 
-model = ModelParams(t, U)
+model = HubbardParams(t, U)
 calc = CalcConfig(symm, model)
 
 # Step 3: Compute the ground state
@@ -85,7 +85,7 @@ U = Dict(
     (2,1,2,1) => 1.0
 )
 
-model = ModelParams(bands, t, U)
+model = HubbardParams(bands, t, U)
 calc = CalcConfig(symm, model)
 
 # Step 3: Compute the ground state

--- a/docs/src/Examples.md
+++ b/docs/src/Examples.md
@@ -48,7 +48,7 @@ ex = compute_excitations(gs, momenta, charges)
   - The **particle** and **spin** symmetries (`Trivial`, `U1Irrep`, or `SU2Irrep`)
   - The **number of sites in the unit cell** (`cell_width`)
   - The **filling fraction**, defined by `N_electrons / N_sites` via the keyword `filling=(N_electrons, N_sites)`
-- The `ModelParams` constructor shown above is the simplest form, suitable for single-band Hubbard models.
+- The `HubbardParams` constructor shown above is the simplest form, suitable for single-band Hubbard models.
 
 ---
 
@@ -114,5 +114,5 @@ ex = compute_excitations(gs, momenta, charges)
 ---
 
 📘 **Tip:**  
-For advanced use cases (custom operators, constrained symmetry sectors, or DMRG sweep control), see the API reference for  
-[`compute_groundstate`](@ref), [`compute_excitations`](@ref), and [`ModelParams`](@ref).
+For advanced use cases (custom operators, constrained symmetry sectors, or DMRG sweep control), see the API reference for 
+[`HubbardParams`](@ref), [`CalcConfig`](@ref), and [`compute_groundstate`](@ref).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ A typical HubbardTN simulation follows a clear sequence of steps:
    These are specified in a [`SymmetryConfig`](@ref) object.
 
 2. **Specify the model parameters.**  
-   Insert your model’s coupling constants and hopping terms into a [`ModelParams`](@ref) object.  
+   Insert your model’s coupling constants and hopping terms into a [`HubbardParams`](@ref) object.  
    This defines the Hamiltonian that will be constructed.
 
 3. **Compute physical quantities.**  

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ You can install `HubbardTN` directly from its GitHub repository:
 
 ```julia
 julia> using Pkg
-julia> Pkg.add(url="https://github.com/DaanVrancken/HubbardTN.jl")
+julia> Pkg.add("HubbardTN")
 ```
 After installation, load the package with:
 ```
@@ -40,3 +40,4 @@ A typical HubbardTN simulation follows a clear sequence of steps:
    - Compute the **ground state** using [`compute_groundstate`](@ref).
    - Obtain **excitations** with [`compute_excitations`](@ref).
    - Investigate **domain walls** via [`compute_domainwall`](@ref).
+   - ...

--- a/examples/01_one_band_U1xSU2.jl
+++ b/examples/01_one_band_U1xSU2.jl
@@ -13,7 +13,7 @@ symm = SymmetryConfig(particle_symmetry, spin_symmetry, cell_width, filling)
 t = [0.0, 1.0]   # [chemical_potential, nn_hopping, nnn_hopping, ...]
 U = [4.0]        # [on-site interaction, nn_interaction, ...]
 
-model = ModelParams(t, U)
+model = HubbardParams(t, U)
 calc = CalcConfig(symm, model)
 
 # Step 3: Compute the ground state

--- a/examples/01_one_band_U1xSU2.jl
+++ b/examples/01_one_band_U1xSU2.jl
@@ -32,7 +32,7 @@ ent = entanglement_spectrum(ψ)
 println("Entanglement spectrum: \n")
 display(ent)
 
-Ne = density_e(ψ, symm)
+Ne = density_e(ψ, calc)
 println("Number of electrons per site: ", Ne)
 
 # Step 4: Compute first excitation in fZ2(0) × U1Irrep(0) × SU2Irrep(0) sector

--- a/examples/02_one_band_TrivialxU1.jl
+++ b/examples/02_one_band_TrivialxU1.jl
@@ -12,7 +12,7 @@ symm = SymmetryConfig(particle_symmetry, spin_symmetry, cell_width)
 t = [2.0, 1.0]   # [chemical_potential, nn_hopping, nnn_hopping, ...]
 U = [4.0]        # [on-site interaction, nn_interaction, ...]
 
-model = ModelParams(t, U)
+model = HubbardParams(t, U)
 calc = CalcConfig(symm, model)
 
 # Step 3: Compute the ground state

--- a/examples/02_one_band_TrivialxU1.jl
+++ b/examples/02_one_band_TrivialxU1.jl
@@ -31,12 +31,12 @@ ent = entanglement_spectrum(ψ)
 println("Entanglement spectrum: \n")
 display(ent)
 
-Ne = density_e(ψ, symm)
+Ne = density_e(ψ, calc)
 println("Number of electrons per site: ", Ne)
 
-u, d = density_spin(ψ, symm)
+u, d = density_spin(ψ, calc)
 println("Spin up per site: ", u)
 println("Spin down per site: ", d)
 
-Ms = calc_ms(ψ, symm)
+Ms = calc_ms(ψ, calc)
 println("Staggered magnetization: ", Ms)

--- a/examples/03_two_band.jl
+++ b/examples/03_two_band.jl
@@ -26,7 +26,7 @@ U = Dict(
     (2,1,2,1) => 1.0
 )
 
-model = ModelParams(bands, t, U)
+model = HubbardParams(bands, t, U)
 calc = CalcConfig(symm, model)
 
 # Step 3: Compute the ground state

--- a/examples/04_staggered_magnetization.jl
+++ b/examples/04_staggered_magnetization.jl
@@ -22,7 +22,7 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
                                 max_iter::Int=5, tol::Float64=1e-4, svalue::Float64=2.5)
     Ms = 0.0
     ψ_init = nothing
-    Ms_list = Float64[]
+    Ms_list = Float64[Ms]
     E_list = Float64[]
 
     println("Starting self-consistent calculation of staggered magnetization")

--- a/examples/04_staggered_magnetization.jl
+++ b/examples/04_staggered_magnetization.jl
@@ -22,7 +22,7 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
                                 max_iter::Int=5, tol::Float64=1e-4, svalue::Float64=2.5)
     Ms = 0.0
     ψ_init = nothing
-    Ms_list = Float64[Ms]
+    Ms_list = Float64[]
     E_list = Float64[]
 
     println("Starting self-consistent calculation of staggered magnetization")
@@ -31,8 +31,8 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
         println("\n--- Iteration $i: Ms = $Ms ---")
         
         # Step 2: Set up model parameters with current Ms
-        model = ModelParams(t, U; J_M0=(J_inter, Ms))
-        calc = CalcConfig(symm, model)
+        model = HubbardParams(t, U)
+        calc = CalcConfig(symm, model, StaggeredField(J_inter, Ms))
 
         # Step 3: Compute the ground state
         gs = compute_groundstate(calc; svalue = svalue, init_state=ψ_init)

--- a/examples/04_staggered_magnetization.jl
+++ b/examples/04_staggered_magnetization.jl
@@ -46,7 +46,7 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
         push!(E_list, E)
         
         # Step 4: Calculate new Ms
-        Ms_new = calc_ms(ψ, symm)
+        Ms_new = calc_ms(ψ, calc)
         Ms_change = abs(Ms_new - Ms)
         push!(Ms_list, Ms_new)
         

--- a/examples/05_Hubbard_Holstein.jl
+++ b/examples/05_Hubbard_Holstein.jl
@@ -1,5 +1,5 @@
 using HubbardTN
-using TensorKit, MPSKit, Statistics
+using TensorKit, MPSKit
 
 # Step 1: Define the symmetries
 particle_symmetry = Trivial
@@ -12,7 +12,7 @@ symm = SymmetryConfig(particle_symmetry, spin_symmetry, cell_width)
 t = [2.0, 1.0]   # [chemical_potential, nn_hopping, nnn_hopping, ...]
 U = [4.0]        # [on-site interaction, nn_interaction, ...]
 w = 1.0
-g = 0.0
+g = [0.5]
 max_b = 4
 
 model = HubbardParams(t, U)
@@ -34,14 +34,14 @@ ent = entanglement_spectrum(ψ)
 println("Entanglement spectrum: \n")
 display(ent)
 
-Ne = density_e_HH(ψ, symm)
+Ne = density_e(ψ, calc)
 println("Number of electrons per site: ", Ne)
-println("Mean number of electrons = ", mean(Ne))
+println("Mean number of electrons = ", sum(Ne)/length(Ne))
 
-Nb = density_b(ψ, symm, max_b)
+Nb = density_b(ψ, calc)
 println("Number of phonons per site: ", Nb)
-println("Mean number of phonons = ", mean(Nb))
+println("Mean number of phonons = ", sum(Nb)/length(Nb))
 
-u, d = density_spin_HH(ψ, symm)
+u, d = density_spin(ψ, calc)
 println("Spin up: $u")
 println("Spin down: $d")

--- a/examples/05_Hubbard_Holstein.jl
+++ b/examples/05_Hubbard_Holstein.jl
@@ -15,8 +15,8 @@ w = 1.0
 g = 0.0
 max_b = 4
 
-model = HolsteinParams(t, U, w, g, max_b)
-calc = CalcConfig(symm, model)
+model = HubbardParams(t, U)
+calc  = CalcConfig(symm, model, HolsteinTerm(w, g, max_b, 1.0))
 
 # Step 3: Compute the ground state
 gs = compute_groundstate(calc; svalue = 3.0)

--- a/src/HubbardTN.jl
+++ b/src/HubbardTN.jl
@@ -7,8 +7,7 @@ export SymmetryConfig, HubbardParams, CalcConfig
 export ThreeBodyTerm, MagneticField, StaggeredField, HolsteinTerm
 export hamiltonian, compute_groundstate, find_chemical_potential
 export compute_excitations, compute_domainwall
-export dim_state, density_e, density_spin, calc_ms
-export density_e_HH, density_b, density_spin_HH
+export dim_state, density_e, density_b, density_spin, calc_ms
 export save_computation, load_computation, save_state, load_state
 
 using MPSKit, MPSKitModels

--- a/src/HubbardTN.jl
+++ b/src/HubbardTN.jl
@@ -2,21 +2,22 @@ module HubbardTN
 
 export hubbard_space, c_plusmin_up, c_plusmin_down, c_minplus_up, c_minplus_down
 export c_plusmin, c_minplus, number_up, number_down, number_e, number_pair, Sz
-export holstein_space, b_plus, b_min, number_b
-export SymmetryConfig, ModelParams, CalcConfig, HolsteinParams
+export b_plus, b_min, number_b
+export SymmetryConfig, HubbardParams, CalcConfig
+export ThreeBodyTerm, MagneticField, StaggeredField, HolsteinTerm
 export hamiltonian, compute_groundstate, find_chemical_potential
 export compute_excitations, compute_domainwall
 export dim_state, density_e, density_spin, calc_ms
 export density_e_HH, density_b, density_spin_HH
 export save_computation, load_computation, save_state, load_state
 
-#using LinearAlgebra
 using MPSKit, MPSKitModels
 using TensorKit, KrylovKit
 using JLD2
 
 include("models.jl")
 include("operators.jl")
+include("boson_operators.jl")
 include("hamiltonian.jl")
 include("groundstate.jl")
 include("excitations.jl")

--- a/src/boson_operators.jl
+++ b/src/boson_operators.jl
@@ -26,7 +26,7 @@ function b_plus(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cut
     I = sectortype(b⁺)
     charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
     for i in 1:cutoff
-        block(b⁺, I(charges...))[i + 1, i] = sqrt(i)
+        block(b⁺, I(charges...))[i+1, i] = sqrt(i)
     end
 
     return b⁺
@@ -45,7 +45,7 @@ function b_min(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cuto
     I = sectortype(b⁻)
     charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
     for i in 1:cutoff
-        block(b⁻, I(charges...))[i + 1, i] = sqrt(i)
+        block(b⁻, I(charges...))[i, i+1] = sqrt(i)
     end
 
     return b⁻
@@ -64,7 +64,7 @@ function number_b(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, c
     I = sectortype(nb)
     charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
     for i in 1:cutoff
-        block(nb, I(charges...))[i + 1, i + 1] = i
+        block(nb, I(charges...))[i+1, i+1] = i
     end
 
     return nb

--- a/src/boson_operators.jl
+++ b/src/boson_operators.jl
@@ -1,0 +1,71 @@
+#############
+# Operators #
+#############
+
+"""
+    boson_space(ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...)
+
+The bosonic physical space compatible with a Hubbard space with particle symmetry `ps` 
+and spin symmetry `ss`, truncated at a maximum of `cutoff` bosons per site.
+"""
+function boson_space(ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...)
+    space = unitspace(hubbard_space(ps, ss; kwargs...))
+    return ⊕((space for _ in 0:cutoff)...)
+end
+
+"""
+    b_plus(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64)
+
+The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
+"""
+b_plus(ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...) = b_plus(ComplexF64, ps, ss, cutoff; kwargs...)
+function b_plus(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...)
+    pspace = boson_space(ps, ss, cutoff; kwargs...)
+
+    b⁺ = zeros(elt, pspace ← pspace)
+    I = sectortype(b⁺)
+    charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
+    for i in 1:cutoff
+        block(b⁺, I(charges...))[i + 1, i] = sqrt(i)
+    end
+
+    return b⁺
+end
+
+"""
+    b_min(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64)
+
+The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
+"""
+b_min(ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...) = b_min(ComplexF64, ps, ss, cutoff; kwargs...)
+function b_min(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...)
+    pspace = boson_space(ps, ss, cutoff; kwargs...)
+
+    b⁻ = zeros(elt, pspace ← pspace)
+    I = sectortype(b⁻)
+    charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
+    for i in 1:cutoff
+        block(b⁻, I(charges...))[i + 1, i] = sqrt(i)
+    end
+
+    return b⁻
+end
+
+"""
+    number_b(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64)
+
+The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
+"""
+number_b(ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...) = number_b(ComplexF64, ps, ss, cutoff; kwargs...)
+function number_b(elt::Type{<:Number}, ps::Type{<:Sector}, ss::Type{<:Sector}, cutoff::Int64; kwargs...)
+    pspace = boson_space(ps, ss, cutoff; kwargs...)
+
+    nb = zeros(elt, pspace ← pspace)
+    I = sectortype(nb)
+    charges = (0 for _ in 1:length(fieldtypes(I)[1].parameters))
+    for i in 1:cutoff
+        block(nb, I(charges...))[i + 1, i + 1] = i
+    end
+
+    return nb
+end

--- a/src/excitations.jl
+++ b/src/excitations.jl
@@ -32,7 +32,7 @@ function compute_excitations(
     envs = groundstate_dict["environments"]
 
     trivial_sector = first(sectors(oneunit(physicalspace(H, 1))))
-    @assert length(charges) == length(trivial_sector) "Number of charges must match number of symmetries."
+    @assert length(charges) == length(trivial_sector) "Number of charges must match number of symmetries ($(length(trivial_sector)))."
     sector = foldl(⊠, [typeof(f)(charges[i]) for (i, f) in enumerate((trivial_sector))])
 
     Es, qps = excitations(H, QuasiparticleAnsatz(solver, MPSKit.Defaults.alg_environments(;dynamic_tols=false)), 
@@ -77,7 +77,7 @@ function compute_domainwall(
     envs = groundstate_dict["environments"]
 
     trivial_sector = first(sectors(oneunit(physicalspace(H, 1))))
-    @assert length(charges) == length(trivial_sector) "Number of charges must match number of symmetries."
+    @assert length(charges) == length(trivial_sector) "Number of charges must match number of symmetries ($(length(trivial_sector)))."
     sector = foldl(⊠, [typeof(f)(charges[i]) for (i, f) in enumerate((trivial_sector))])
 
     ψ_s = circshift(ψ, shift)

--- a/src/groundstate.jl
+++ b/src/groundstate.jl
@@ -179,10 +179,10 @@ function calculate_filling(calc::CalcConfig,
                             svalue::Float64=2.0, 
                             init_state::Union{Nothing, InfiniteMPS}=nothing
                         )
-    simul = CalcConfig(calc.symmetries, change_chemical_potential(calc.hubbard, μ))
+    simul = CalcConfig(calc.symmetries, change_chemical_potential(calc.hubbard, μ), calc.terms)
     gs = compute_groundstate(simul; svalue=svalue, init_state=init_state)
     ψ = gs["groundstate"]
-    filling = sum(density_e(ψ, calc.symmetries)) / length(ψ)
+    filling = sum(density_e(ψ, calc)) / length(ψ)
 
     return filling, ψ
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -51,7 +51,7 @@ struct SymmetryConfig
             numerator, denominator = filling
             @assert numerator > 0 && denominator > 0 "Filling components must be positive integers"
             necessary_width = denominator * (mod(numerator, 2) + 1)
-            @assert cell_width % necessary_width == 0 "Cell width ($cell_width) must be a multiple of $necessary_width \
+            @assert cell_width % necessary_width == 0 "Cell width ($cell_width) must be a multiple of $necessary_width 
                                                        to accommodate the specified filling ($numerator / $denominator)"
         elseif filling !== nothing
             error("Filling can only be specified when particle symmetry is U1Irrep, but got $(particle_symmetry).")
@@ -62,9 +62,9 @@ struct SymmetryConfig
 end
 
 
-####################
-# Model parameters #
-####################
+#################
+# Hubbard model #
+#################
 
 # Convert hopping matrix to dictionary representation
 function hopping_matrix2dict(t::Union{Vector{T}, Matrix{T}}) where {T<:AbstractFloat}
@@ -102,111 +102,52 @@ function addU!(U::Dict{NTuple{4,Int},T}, key::NTuple{4,Int}, val::T) where {T}
         U[(l,k,j,i)] = conj(val)          # Hermitian conjugate term
     end
 end
-# Add 3-body interaction term and its Hermitian conjugate
-function addV!(V::Dict{NTuple{6,Int},T}, key::NTuple{6,Int}, val::T) where {T}
-    if val != 0
-        V[key] = val
-        i,j,k,l,n,m = key
-        V[(m,n,l,k,j,i)] = conj(val)          # Hermitian conjugate term
-    end
-end
-# Make
-function three_body_term(i::Int64, j::Int64, value::T, V::Dict{NTuple{6,Int},T}=Dict{NTuple{6,Int},T}()) where {T<:AbstractFloat}
-    addV!(V, (i,i,j,j,i,i), value)
-    addV!(V, (i,j,i,i,j,i), value)
-    addV!(V, (j,i,i,i,i,j), value)
-    addV!(V, (i,j,j,j,j,i), value)
-    addV!(V, (j,i,j,j,i,j), value)
-    addV!(V, (j,j,i,i,j,j), value)
-    return V
-end
 
 """
-    ModelParams{T<:AbstractFloat}
+    HubbardParams{T<:AbstractFloat}
 
-Represents the Hamiltonian parameters for a lattice or multi-orbital system,
-including hopping terms, two-body, and three-body interactions.
+Represents the standard Hubbard Hamiltonian parameters for a lattice or
+multi-orbital system.
 
 # Fields
 - `bands::Int64`  
-    Number of orbitals or bands per unit cell. Must be positive.
+    Number of electronic orbitals or bands per unit cell. Must be positive.
 - `t::Dict{NTuple{2, Int64}, T}`  
-    Hopping amplitudes between sites. Convention: `t[(i,i)] = μ_i` is the on-site potential,
+    Hopping amplitudes. Convention: `t[(i,i)] = μ_i` is the on-site potential,
     `t[(i,j)]` for `i ≠ j` is the hopping amplitude from site i to j.
 - `U::Dict{NTuple{4, Int64}, T}`  
-    Two-body interaction tensor. Entries `U[(i,j,k,l)]` correspond to the operator
-    c⁺_i c⁺_j c_k c_l. Zero entries can be omitted from the dictionary.
-- `V::Dict{NTuple{6, Int64}, T}`  
-    Three-body interaction tensor. Entries `V[(i,j,k,l,m,n)]` correspond to the operator
-    c⁺_i c⁺_j c⁺_k c_l c_m c_n. Zero entries can be omitted from the dictionary.
-- `J_M0::NTuple{2, T}`  
-    Tuple containing inter-chain Hund's coupling `J` and initial staggered magnetization `M0`. Only implemented for single-band models.
+    Two-body electronic interaction tensor. Entries `U[(i,j,k,l)]` correspond
+    to the operator c⁺_i c⁺_j c_k c_l. Zero entries can be omitted.
 
 # Constructors
-
-1. `ModelParams(bands::Int64, t::Dict{NTuple{2, Int64}, T}, U::Dict{NTuple{4,Int},T})`  
-   Standard constructor with explicit number of bands, hopping dictionary, and interaction dictionary. `V` is empty by default.
-2. `ModelParams(bands::Int64, t::Dict{NTuple{2, Int64}, T}, U::Dict{NTuple{4,Int},T}, V::Dict{NTuple{6, Int64},T})`  
-   Constructor including three-body interactions.
-3. `ModelParams(t::Vector{T}, U::Dict{NTuple{4,Int},T})`  
-   Single-band constructor from hopping vector and two-body interaction dictionary.
-4. `ModelParams(t::Vector{T}, U::Vector{T}; J_M0::NTuple{2, T}=(0.0,0.0)))`  
-   Single-band constructor from hopping vector, a vector of on-site interactions, and optionally staggered magnetic field parameters. 
-   Converts the vector automatically into the interaction dictionary.
-5. `ModelParams(t::Matrix{T}, U::Matrix{T})`  
-   Multi-band constructor from hopping matrix and two-body interaction matrix. Checks Hermiticity and dimensions, converts into internal dictionary format.
-6. `ModelParams(t::Vector{T}, U::Vector{T}, V::Vector{T})`  
-   Single-band constructor including three-body interactions. Converts vectors into dictionaries internally.
-7. `ModelParams(t::Matrix{T}, U::Matrix{T}, V::Matrix{T})`  
-   Multi-band constructor including three-body interactions. Converts matrices into dictionaries and checks Hermiticity.
-
-# Notes
-- Hopping and interaction arrays or vectors are automatically converted into the internal `Dict` representation.
-- Hermiticity of on-site interaction matrices is asserted when applicable.
-- The interaction dictionaries are structured for direct use in many-body Hamiltonian construction.
-- Zero entries in `U` or `V` can be omitted from the dictionaries.
+- `HubbardParams(bands, t::Dict, U::Dict)` — standard constructor specifying bands, hopping, and interactions.
+- `HubbardParams(t::Vector, U::Vector)` — single-band convenience constructor from vectors.
+- `HubbardParams(t::Matrix, U::Matrix)` — multi-band constructor from matrices; automatically checks dimensions and Hermiticity.
 """
-struct ModelParams{T<:AbstractFloat}
+struct HubbardParams{T<:AbstractFloat}
     bands::Int64
     t::Dict{NTuple{2, Int64}, T}          # t_ii=µ_i, t_ij hopping i→j
     U::Dict{NTuple{4, Int64}, T}          # U_ijkl c⁺_i c⁺_j c_k c_l
-    V::Dict{NTuple{6, Int64}, T}          # 3-body interaction V_ijklmn c⁺_i c⁺_j c⁺_k c_l c_m c_n
-    J_M0::NTuple{2, T}                    # Staggered magnetic interaction J with initial magnetization M0
 
-    function ModelParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, U::Dict{NTuple{4,Int},T}) where {T<:AbstractFloat}
+    function HubbardParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, U::Dict{NTuple{4,Int},T}) where {T<:AbstractFloat}
         @assert bands > 0 "Number of bands must be a positive integer"
-        new{T}(bands, t, U, Dict(), (0.0,0.0))
-    end
-    function ModelParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, 
-                        U::Dict{NTuple{4,Int},T}, V::Dict{NTuple{6, Int64}, T}) where {T<:AbstractFloat}
-        @assert bands > 0 "Number of bands must be a positive integer"
-        new{T}(bands, t, U, V, (0.0,0.0))
-    end
-    function ModelParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, 
-                        U::Dict{NTuple{4,Int},T}, J_M0::NTuple{2, T}) where {T<:AbstractFloat}
-        @assert bands == 1 "Staggered magnetization field term is only implemented for single-band models."
-        new{T}(bands, t, U, Dict(), J_M0)
-    end
-    function ModelParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, U::Dict{NTuple{4,Int},T}, 
-             V::Dict{NTuple{6, Int64}, T}, J_M0::NTuple{2, T}) where {T<:AbstractFloat}
-        @assert bands == 1 "Staggered magnetization field term is only implemented for single-band models."
-        new{T}(bands, t, U, V, J_M0)
+        new{T}(bands, t, U)
     end
 end
 # Constructors
-function ModelParams(t::Union{Vector{T}, Matrix{T}}, U::Dict{NTuple{4,Int},T}) where {T<:AbstractFloat}
+function HubbardParams(t::Union{Vector{T}, Matrix{T}}, U::Dict{NTuple{4,Int},T}) where {T<:AbstractFloat}
     bands = isa(t, Matrix) ? size(t,1) : 1
-    return ModelParams(bands, hopping_matrix2dict(t), U)
+    return HubbardParams(bands, hopping_matrix2dict(t), U)
 end
-function ModelParams(t::Vector{T}, U::Vector{T}; J_M0::NTuple{2, T}=(0.0,0.0)) where {T<:AbstractFloat}
+function HubbardParams(t::Vector{T}, U::Vector{T}) where {T<:AbstractFloat}
     interaction = Dict{NTuple{4,Int},T}()
     for (i, val) in enumerate(U)
         addU!(interaction, (1,i,i,1), val)
-        addU!(interaction, (i,1,1,i), val)  # double counting: factor 1/2 added later
+        addU!(interaction, (i,1,1,i), val)
     end
-    return ModelParams(1, hopping_matrix2dict(t), interaction, J_M0)
+    return HubbardParams(1, hopping_matrix2dict(t), interaction)
 end
-function ModelParams(t::Matrix{T}, U::Matrix{T}) where {T<:AbstractFloat}
+function HubbardParams(t::Matrix{T}, U::Matrix{T}) where {T<:AbstractFloat}
     bands = size(t, 1)
 
     # --- basic checks ---
@@ -222,60 +163,144 @@ function ModelParams(t::Matrix{T}, U::Matrix{T}) where {T<:AbstractFloat}
         end
     end
 
-    return ModelParams(bands, hopping_matrix2dict(t), interaction)
+    return HubbardParams(bands, hopping_matrix2dict(t), interaction)
 end
-function ModelParams(t::Vector{T}, U::Vector{T}, V::Vector{T}) where {T<:AbstractFloat}
-    model_base = ModelParams(t, U)
+
+
+###############
+# Extra terms #
+###############
+
+abstract type AbstractHamiltonianTerm end
+
+# Add 3-body interaction term and its Hermitian conjugate
+function addV!(V::Dict{NTuple{6,Int},T}, key::NTuple{6,Int}, val::T) where {T}
+    if val != 0
+        V[key] = val
+        i,j,k,l,n,m = key
+        V[(m,n,l,k,j,i)] = conj(val)          # Hermitian conjugate term
+    end
+end
+# Add standard 3-body interaction terms to dictionary
+function dominant_threebody_term(i::Int64, j::Int64, value::T, V::Dict{NTuple{6,Int},T}=Dict{NTuple{6,Int},T}()) where {T<:AbstractFloat}
+    addV!(V, (i,i,j,j,i,i), value)
+    addV!(V, (i,j,i,i,j,i), value)
+    addV!(V, (j,i,i,i,i,j), value)
+    addV!(V, (i,j,j,j,j,i), value)
+    addV!(V, (j,i,j,j,i,j), value)
+    addV!(V, (j,j,i,i,j,j), value)
+    return V
+end
+
+"""
+    ThreeBodyTerm{T<:AbstractFloat} <: AbstractHamiltonianTerm
+
+Represents three-body interactions in the Hamiltonian.
+
+# Fields
+- `bands::Int64`  
+    Number of bands (orbitals) in the system.
+- `V::Dict{NTuple{6,Int}, T}`  
+    Three-body interaction amplitudes `c⁺_i c⁺_j c⁺_k c_l c_m c_n`. Zero
+    entries can be omitted.
+
+# Constructors
+- `ThreeBodyTerm(V::Vector{T})` — single-band constructor from a vector.
+- `ThreeBodyTerm(V::Matrix{T})` — multi-band constructor from a matrix.
+"""
+struct ThreeBodyTerm{T<:AbstractFloat} <: AbstractHamiltonianTerm
+    bands::Int64
+    V::Dict{NTuple{6,Int}, T}
+end
+# Constructors
+function ThreeBodyTerm(V::Vector{T}) where {T<:AbstractFloat}
     threebody = Dict{NTuple{6,Int},T}()
     for (i, val) in enumerate(V)
-        threebody = three_body_term(1, i+1, val, threebody)
+        threebody = dominant_threebody_term(1, i+1, val, threebody)
     end
 
-    return ModelParams(model_base.bands, model_base.t, model_base.U, threebody)
+    return ThreeBodyTerm(1, threebody)
 end
-function ModelParams(t::Matrix{T}, U::Matrix{T}, V::Matrix{T}) where {T<:AbstractFloat}
-    model_base = ModelParams(t, U)
-    bands = model_base.bands
-    @assert size(V, 1) == bands "First dimension of V ($(size(V,1))) must be equal to number of bands ($bands)"
+function ThreeBodyTerm(V::Matrix{T}) where {T<:AbstractFloat}
+    bands = size(V, 1)
     @assert size(V, 2) % bands == 0 "Second dimension of V ($(size(V,2))) must be multiple of number of bands ($bands)"
     @assert ishermitian(V[1:bands, 1:bands]) "V on-site matrix is not Hermitian"
 
     threebody = Dict{NTuple{6,Int},T}()
     for i in 1:bands
         for j in 1:size(V,2)
-            threebody = three_body_term(i, j, V[i,j], threebody)
+            threebody = dominant_threebody_term(i, j, V[i,j], threebody)
         end
     end
 
-    return ModelParams(model_base.bands, model_base.t, model_base.U, threebody)
+    return ThreeBodyTerm(bands, threebody)
 end
 
-##########################
-# Hubbard Holstein model #
-##########################
+"""
+    MagneticField{T<:AbstractFloat} <: AbstractHamiltonianTerm
 
-struct HolsteinParams{T<:AbstractFloat}
-    bands::Int64
-    t::Dict{NTuple{2, Int64}, T}          # t_ii=µ_i, t_ij hopping i→j
-    U::Dict{NTuple{4, Int64}, T}          # U_ijkl c⁺_i c⁺_j c_k c_l
-    w::T                                  # Phonon frequency
-    g::T                                  # Electron-phonon coupling strength
-    max_b::Int64                          # Max allowed phonons per site
+Represents a magnetic field term in the Hamiltonian `B * Sᶻ`.
 
-    function HolsteinParams(bands::Int64, t::Dict{NTuple{2,Int64}, T}, U::Dict{NTuple{4,Int},T}, w::T, g::T, max_b::Int64) where {T<:AbstractFloat}
-        @assert bands > 0 "Number of bands must be a positive integer"
-        @assert max_b > 0 "Max allowed number of phonons must be a positive integer"
-        new{T}(bands, t, U, w, g, max_b)
-    end
-end
+# Fields
+- `B::T`  
+    Magnetic field strength.
+
 # Constructors
-function HolsteinParams(t::Vector{T}, U::Vector{T}, w::T=0.0, g::T=0.0, max_b::Int64=1) where {T<:AbstractFloat}
-    interaction = Dict{NTuple{4,Int},T}()
-    for (i, val) in enumerate(U)
-        addU!(interaction, (1,i,i,1), val)
-        addU!(interaction, (i,1,1,i), val)
+- `MagneticField(B)` — creates the term with specified magnetic field strength.
+"""
+struct MagneticField{T<:AbstractFloat} <: AbstractHamiltonianTerm
+    B::T            # Magnetic field strength
+end
+
+"""
+    StaggeredField{T<:AbstractFloat} <: AbstractHamiltonianTerm
+
+Represents a staggered magnetic field term in the Hamiltonian. 
+For multi-band models, the staggering is applied between equivalent orbitals.
+
+# Fields
+- `J::T`  
+    Inter-chain Hund's coupling.
+- `Ms::T`  
+    Initial staggered magnetization.
+
+# Constructors
+- `StaggeredField(J, Ms)` — creates the term with specified coupling and initial magnetization.
+"""
+struct StaggeredField{T<:AbstractFloat} <: AbstractHamiltonianTerm
+    J::T            # Inter-chain Hund's coupling
+    Ms::T           # Initial staggered magnetization
+end
+
+"""
+    HolsteinTerm{T<:AbstractFloat} <: AbstractHamiltonianTerm
+
+Represents a Holstein-type electron–phonon coupling terms `w b⁺ᵢ bᵢ` and`gₐ(nᵢₐ-<n>)(b⁺ᵢ + bᵢ)` in the Hamiltonian.
+
+# Fields
+- `w::T`  
+    Local phonon frequency.
+- `g::Vector{T}`  
+    Electron–phonon coupling strength per Hubbard band.
+- `max_b::Int64`  
+    Maximum number of phonons allowed per site.
+- `mean_ne::T`  
+    Mean number of electrons in Hubbard model.
+
+# Constructors
+- `HolsteinTerm(w, g, max_b, mean_ne)` — creates the term with specified phonon frequency,
+  coupling, and phonon truncation.
+"""
+struct HolsteinTerm{T<:AbstractFloat} <: AbstractHamiltonianTerm
+    w::T                        # Phonon frequency in term `w b⁺ᵢ bᵢ`
+    g::Vector{T}                # Electron-phonon coupling strength per Hubbard band
+    max_b::Int64                # Max allowed phonons per site
+    mean_ne::T                  # Mean number of electrons in Hubbard model
+
+    function HolsteinTerm(w::T, g::Vector{T}, max_b::Int64, mean_ne::T) where {T<:AbstractFloat}
+        @assert max_b > 0 "Max allowed number of phonons must be a positive integer"
+        new{T}(w, g, max_b, mean_ne)
     end
-    return HolsteinParams(1, hopping_matrix2dict(t), interaction, w, g, max_b)
 end
 
 
@@ -283,20 +308,71 @@ end
 # Calculation set up #
 ######################
 
-"""
-    CalcConfig
+# Check for duplicate Hamiltonian terms
+function find_duplicate(terms::Tuple)
+    for (i, t) in enumerate(terms)
+        T = typeof(t)
+        for s in terms[i+1:end]
+            typeof(s) === T && return T
+        end
+    end
+    return nothing
+end
 
-Holds all configuration information for a lattice calculation, including
-symmetries and model parameters.
+"""
+    CalcConfig{T<:AbstractFloat, HamiltonianTerms<:Tuple{Vararg{AbstractHamiltonianTerm}}}
+
+Holds all configuration information for a lattice or many-body calculation,
+including symmetries, the base Hubbard Hamiltonian, and optional additional Hamiltonian terms.
 
 # Fields
 - `symmetries::SymmetryConfig`  
-    Contains particle and spin symmetries, unit cell width, and optional filling.
+    Contains particle-number and spin symmetries, unit-cell geometry, and optional filling.
+- `hubbard::HubbardParams{T}`  
+    Base electronic Hamiltonian parameters (bands, hopping, and two-body interactions).
+- `terms::HamiltonianTerms`  
+    Tuple of additional Hamiltonian terms (subtypes of `AbstractHamiltonianTerm`).
 
-- `model::ModelParams{Float64}`  
-    Contains the Hamiltonian parameters: number of bands, hopping amplitudes, and two-body interactions.
+# Constructors
+- `CalcConfig(symmetries, hubbard, terms)` — creates a configuration with specified
+  symmetries, Hubbard parameters, and extra terms. Duplicate term types are checked,
+  and band consistency is enforced.
+- `CalcConfig(symmetries, hubbard, term)` — convenience constructor with one extra term (`terms = (term,)`).
+- `CalcConfig(symmetries, hubbard)` — convenience constructor with no extra terms (`terms = ()`).
 """
-struct CalcConfig{M}
+struct CalcConfig{
+    T<:AbstractFloat,
+    HamiltonianTerms<:Tuple{Vararg{AbstractHamiltonianTerm}}
+}
     symmetries::SymmetryConfig
-    model::M
+    hubbard::HubbardParams
+    terms::HamiltonianTerms
+
+    function CalcConfig(
+                symmetries::SymmetryConfig,
+                hubbard::HubbardParams{T},
+                terms::HamiltonianTerms
+            ) where {T<:AbstractFloat, HamiltonianTerms<:Tuple{Vararg{AbstractHamiltonianTerm}}}
+
+        dup = find_duplicate(terms)
+        dup === nothing || error("Duplicate Hamiltonian term detected: $dup")
+
+        bands = hubbard.bands
+        for term in terms
+            if :bands in fieldnames(typeof(term))
+                @assert term.bands == bands "Number of bands in HubbardParams does not match number of bands in $term"
+            end
+            if term isa HolsteinTerm
+                @assert length(term.g) == bands "Length of electron-phonon coupling vector does not match number of bands in HubbardParams"
+            end
+        end
+
+        new{T, HamiltonianTerms}(symmetries, hubbard, terms)
+    end
+    CalcConfig(
+            symmetries::SymmetryConfig, 
+            hubbard::HubbardParams{T}, 
+            term::AbstractHamiltonianTerm
+        ) where {T<:AbstractFloat} = CalcConfig(symmetries, hubbard, (term,))
+    CalcConfig(symmetries::SymmetryConfig, hubbard::HubbardParams{T}) where {T<:AbstractFloat} = CalcConfig(symmetries, hubbard, ())
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -24,13 +24,6 @@ unit cell width, and optional filling information.
 - `cell_width` must be positive.
 - If `particle_symmetry` is `U1Irrep` and `filling` is specified, the constructor ensures that `cell_width` is a multiple of
   `filling[2] * (mod(filling[1], 2) + 1)` to accommodate the specified filling.
-
-# Examples
-    # Trivial particle and spin symmetry, default cell width
-    cfg1 = SymmetryConfig(Trivial, Trivial)
-
-    # U(1) particle symmetry with SU(2) spin symmetry, cell width 2, filling 1/2
-    cfg2 = SymmetryConfig(U1Irrep, SU2Irrep, cell_width=2, filling=(1,2))
 """
 struct SymmetryConfig
     particle_symmetry::Union{Type{Trivial},Type{U1Irrep},Type{SU2Irrep}}

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -36,7 +36,6 @@ function hubbard_space(::Type{U1Irrep}, ::Type{SU2Irrep}; filling::Tuple{Int64,I
         (0, -P, 0) => 1, (1, Q-P, 1 // 2) => 1, (0, 2Q-P, 0) => 1
     )
 end
-# How to pass (P,Q) to the SU2 case?
 function hubbard_space(::Type{SU2Irrep}, ::Type{Trivial}; kwargs...)
     return Vect[FermionParity ⊠ SU2Irrep]((0, 0) => 2, (1, 1 // 2) => 1)
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -48,9 +48,8 @@ end
 """
     density_b(ψ::InfiniteMPS, symm::SymmetryConfig)
 
-Compute the number of phonons per site in the unit cell.
+Compute the number of bosons per site in the unit cell.
 """
-
 function density_b(ψ::InfiniteMPS, symm::SymmetryConfig, max_b::Int64)
     n = number_b(symm.particle_symmetry, symm.spin_symmetry, max_b)
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -16,84 +16,75 @@ function dim_state(ψ::InfiniteMPS)
 end
 
 """
-    density_e(ψ::InfiniteMPS, symm::SymmetryConfig)
+    density_e(ψ::InfiniteMPS, calc::CalcConfig)
 
 Compute the number of electrons per site in the unit cell.
 """
-function density_e(ψ::InfiniteMPS, symm::SymmetryConfig)
+function density_e(ψ::InfiniteMPS, calc::CalcConfig)
+    symm = calc.symmetries
     n = number_e(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
-    bands = Int(length(ψ)/symm.cell_width)
 
-    Ne = zeros(bands,symm.cell_width)
+    bands = calc.hubbard.bands
+
+    idx = findfirst(t -> t isa HolsteinTerm, calc.terms)
+    boson_site = (idx === nothing ? 0 : 1)
+
+    Ne = zeros(bands, symm.cell_width)
     for i in 1:bands
         for j in 1:symm.cell_width
-            Ne[i,j] = real(expectation_value(ψ, (i+(j-1)*bands) => n))
+            site = i+(j-1)*(bands+boson_site)
+            Ne[i,j] = real(expectation_value(ψ, site => n))
         end
     end
     
     return Ne
 end
 
-function density_e_HH(ψ::InfiniteMPS, symm::SymmetryConfig)
-    n = number_e(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
-
-    Ne = zeros(1,symm.cell_width)
-    for j in 1:symm.cell_width
-        Ne[1,j] = real(expectation_value(ψ, (1+(j-1)*2) => n))
-    end
-    
-    return Ne
-end
-
 """
-    density_b(ψ::InfiniteMPS, symm::SymmetryConfig)
+    density_b(ψ::InfiniteMPS, calc::CalcConfig)
 
 Compute the number of bosons per site in the unit cell.
 """
-function density_b(ψ::InfiniteMPS, symm::SymmetryConfig, max_b::Int64)
-    n = number_b(symm.particle_symmetry, symm.spin_symmetry, max_b)
+function density_b(ψ::InfiniteMPS, calc::CalcConfig)
+    symm = calc.symmetries
+    idx = findfirst(t -> t isa HolsteinTerm, calc.terms)
+    max_b = (idx === nothing ? error("No bosonic terms in model") : calc.terms[idx].max_b)
 
-    Nb = zeros(1,symm.cell_width)
+    n = number_b(symm.particle_symmetry, symm.spin_symmetry, max_b)
+    bands = calc.hubbard.bands
+
+    Nb = zeros(1, symm.cell_width)
     for j in 1:symm.cell_width
-        Nb[1,j] = real(expectation_value(ψ, (j*2) => n))
+        Nb[1,j] = real(expectation_value(ψ, (j-1)*(bands+1) => n))
     end
     
     return Nb
 end
 
 """
-    density_spin(ψ::InfiniteMPS, symm::SymmetryConfig)
+    density_spin(ψ::InfiniteMPS, symm::CalcConfig)
 
-Compute the spin density per site in the unit cell.
+Compute the electron spin density per site in the unit cell.
 """
-function density_spin(ψ::InfiniteMPS, symm::SymmetryConfig)
+function density_spin(ψ::InfiniteMPS, calc::CalcConfig)
+    symm = calc.symmetries
+
     n_up = number_up(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
     n_down = number_down(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
 
-    bands = Int(length(ψ)/symm.cell_width)
+    bands = calc.hubbard.bands
 
+    idx = findfirst(t -> t isa HolsteinTerm, calc.terms)
+    boson_site = (idx === nothing ? 0 : 1)
+    
     Nup = zeros(bands,symm.cell_width);
     Ndown = zeros(bands,symm.cell_width);
     for i in 1:bands
         for j in 1:symm.cell_width
-            Nup[i,j] = real(expectation_value(ψ, (i+(j-1)*bands) => n_up))
-            Ndown[i,j] = real(expectation_value(ψ, (i+(j-1)*bands) => n_down))
+            site = i+(j-1)*(bands+boson_site)
+            Nup[i,j] = real(expectation_value(ψ, site => n_up))
+            Ndown[i,j] = real(expectation_value(ψ, site => n_down))
         end
-    end
-
-    return Nup, Ndown
-end
-
-function density_spin_HH(ψ::InfiniteMPS, symm::SymmetryConfig)
-    n_up = number_up(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
-    n_down = number_down(symm.particle_symmetry, symm.spin_symmetry; filling=symm.filling)
-
-    Nup = zeros(1,symm.cell_width);
-    Ndown = zeros(1,symm.cell_width);
-
-    for j in 1:symm.cell_width
-        Nup[1,j] = real(expectation_value(ψ, (1+(j-1)*2) => n_up))
-        Ndown[1,j] = real(expectation_value(ψ, (1+(j-1)*2) => n_down))
     end
 
     return Nup, Ndown
@@ -104,8 +95,8 @@ end
 
 Compute the staggered magnetization in an InfiniteMPS.
 """
-function calc_ms(ψ::InfiniteMPS, symm::SymmetryConfig)
-    up, down = density_spin(ψ, symm)
+function calc_ms(ψ::InfiniteMPS, calc::CalcConfig)
+    up, down = density_spin(ψ, calc)
     Mag = up - down
     if !all(x -> isapprox(abs(x),abs(Mag[1,1]),rtol=10^(-6)), vec(Mag))
         @warn "Staggerd magnetization varies across unit cell: returning value for first site only."

--- a/test/ChemicalPotential.jl
+++ b/test/ChemicalPotential.jl
@@ -15,7 +15,7 @@ tol = 1e-1
     t = [0.0, 1.0] 
     U = [5.0]
 
-    model = ModelParams(t, U)
+    model = HubbardParams(t, U)
     calc = CalcConfig(symm, model)
 
     mu = find_chemical_potential(calc, 0.75; verbosity=0)

--- a/test/Holstein.jl
+++ b/test/Holstein.jl
@@ -71,7 +71,7 @@ E_ref = -2.038990604938512
     model = HubbardParams([2.0, 1.0], [4.0])
     calc  = CalcConfig(symm, model, HolsteinTerm(w, g, max_b, 1.0))
 
-    gs = compute_groundstate(calc)
+    gs = compute_groundstate(calc; svalue=3.0)
     ψ  = gs["groundstate"]
     H  = gs["ham"]
 
@@ -79,8 +79,8 @@ E_ref = -2.038990604938512
     E0 = sum(real(expectation_value(ψ, H))) / length(ψ)
     @test E0 ≈ E_ref atol=tol
 
-    Ne = density_e_HH(ψ, symm)
-    Nb = density_b(ψ, symm, max_b)
+    Ne = density_e(ψ, calc)
+    Nb = density_b(ψ, calc)
 
     # phonons are present
     @test Nb[1] > 0.0

--- a/test/Holstein.jl
+++ b/test/Holstein.jl
@@ -1,6 +1,6 @@
 println("""
 ##############
-#  One-Band  #
+#  Holstein  #
 ##############
 """)
 
@@ -9,14 +9,13 @@ tol = 1e-2
 E_ref = -1.2713317702997016
 
 @testset "Hubbard–Holstein: g = 0, ω₀ > 0" begin
-
     symm = SymmetryConfig(Trivial, U1Irrep, 2)
     w = 1.0
-    g = 0.0
+    g = [0.0]
     max_b = 4
 
-    model = HolsteinParams([2.0, 1.0], [4.0], w, g, max_b)
-    calc  = CalcConfig(symm, model)
+    model = HubbardParams([2.0, 1.0], [4.0])
+    calc  = CalcConfig(symm, model, HolsteinTerm(w, g, max_b, 1.0))
 
     gs = compute_groundstate(calc)
     ψ  = gs["groundstate"]
@@ -36,15 +35,13 @@ end
 E_ref = -3.2705801927593416
 
 @testset "Hubbard–Holstein: g = 0, ω₀ < 0" begin
-
     symm = SymmetryConfig(Trivial, U1Irrep, 2)
-    
     w = -1.0
-    g = 0.0
+    g = [0.0]
     max_b = 4
 
-    model = HolsteinParams([2.0, 1.0], [4.0], w, g, max_b)
-    calc  = CalcConfig(symm, model)
+    model = HubbardParams([2.0, 1.0], [4.0])
+    calc  = CalcConfig(symm, model, HolsteinTerm(w, g, max_b, 1.0))
 
     gs = compute_groundstate(calc)
     ψ  = gs["groundstate"]
@@ -68,13 +65,13 @@ E_ref = -2.038990604938512
     symm = SymmetryConfig(Trivial, U1Irrep, 2)
     
     w = 1.0
-    g = 2.0
+    g = [2.0]
     max_b = 10
 
-    model = HolsteinParams([2.0, 1.0], [4.0], w, g, max_b)
-    calc  = CalcConfig(symm, model)
+    model = HubbardParams([2.0, 1.0], [4.0])
+    calc  = CalcConfig(symm, model, HolsteinTerm(w, g, max_b, 1.0))
 
-    gs = compute_groundstate(calc; svalue = 3.0)
+    gs = compute_groundstate(calc)
     ψ  = gs["groundstate"]
     H  = gs["ham"]
 
@@ -85,7 +82,7 @@ E_ref = -2.038990604938512
     Ne = density_e_HH(ψ, symm)
     Nb = density_b(ψ, symm, max_b)
 
-    # phonons are activated
+    # phonons are present
     @test Nb[1] > 0.0
     @test Nb[2] > 0.0
 

--- a/test/Holstein.jl
+++ b/test/Holstein.jl
@@ -26,7 +26,7 @@ E_ref = -1.2713317702997016
     @test E0 ≈ E_ref atol=tol
 
     # phonon occupation check
-    Nb = density_b(ψ, symm, max_b)
+    Nb = density_b(ψ, calc)
 
     @test Nb[1] ≈ 0.0 atol=tol
     @test Nb[2] ≈ 0.0 atol=tol
@@ -52,7 +52,7 @@ E_ref = -3.2705801927593416
     @test E0 ≈ E_ref atol=tol
 
     # phonon occupation check
-    Nb = density_b(ψ, symm, max_b)
+    Nb = density_b(ψ, calc)
 
     @test Nb[1] ≈ max_b atol=tol
     @test Nb[2] ≈ max_b atol=tol

--- a/test/MultiBand.jl
+++ b/test/MultiBand.jl
@@ -11,10 +11,10 @@ tol = 1e-2
 # Constructors #
 ################
 
-@testset "ModelParams constructors" begin
-    m1 = ModelParams([0.0 1.0; 1.0 0.0], Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
-    m2 = ModelParams([0.0 1.0; 1.0 0.0], [5.0 0.0; 0.0 3.0])
-    m3 = ModelParams(2, Dict((1,2)=>1.0, (2,1)=>1.0), Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
+@testset "HubbardParams constructors" begin
+    m1 = HubbardParams([0.0 1.0; 1.0 0.0], Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
+    m2 = HubbardParams([0.0 1.0; 1.0 0.0], [5.0 0.0; 0.0 3.0])
+    m3 = HubbardParams(2, Dict((1,2)=>1.0, (2,1)=>1.0), Dict((1,1,1,1)=>5.0, (2,2,2,2)=>3.0))
     @test m1.bands == m2.bands == m3.bands
     @test m1.t == m2.t == m3.t
     @test m1.U == m2.U == m3.U
@@ -49,7 +49,7 @@ U =Dict((1,1,1,1)=>4.0,  # Direct on-site
         (1,2,3,4)=>0.1,  # Four distinct sites
         (4,3,2,1)=>0.1)
 
-model = ModelParams(t , U)
+model = HubbardParams(t , U)
 calc = CalcConfig(symm, model)
 
 E_norm = 0.38791

--- a/test/OneBand.jl
+++ b/test/OneBand.jl
@@ -105,12 +105,12 @@ end
     @test typeof(D) == Vector{Int64}
     @test D > zeros(size(D))
 
-    electron_number = sum(density_e(psi, symm))/length(psi)
+    electron_number = sum(density_e(psi, calc))/length(psi)
     @test sum(electron_number)≈symm.filling[1]/symm.filling[2] atol=1e-8
 
-    Nup, Ndown = density_spin(psi, symm)
+    Nup, Ndown = density_spin(psi, calc)
     @test sum(Nup+Ndown)/length(psi)≈symm.filling[1]/symm.filling[2] atol=1e-8
 
-    ms = calc_ms(psi, symm)
+    ms = calc_ms(psi, calc)
     @test typeof(ms) == Float64
 end

--- a/test/OneBand.jl
+++ b/test/OneBand.jl
@@ -19,7 +19,7 @@ E_norm = [-1.26967, -1.03717, -0.84145, -0.68707, -0.57119]
 @testset "Dependence on parameters U1xSU2" for u in u_range
     ind = Int(u) + 1
     symm = SymmetryConfig(U1Irrep, SU2Irrep, 2, (1,1))
-    model = ModelParams([0.0, 1.0], [u])
+    model = HubbardParams([0.0, 1.0], [u])
     calc = CalcConfig(symm, model)
     gs = compute_groundstate(calc; tol=tol/10)
     ψ₀ = gs["groundstate"]
@@ -35,7 +35,7 @@ E_norm = [-1.273, -1.540, -1.844, -2.190, -2.5736]
 @testset "Dependence on parameters TrivialxU1" for u in u_range
     ind = Int(u) + 1
     symm = SymmetryConfig(Trivial, U1Irrep, 2)
-    model = ModelParams([u/2, 1.0], [u])
+    model = HubbardParams([u/2, 1.0], [u])
     calc = CalcConfig(symm, model)
     gs = compute_groundstate(calc; tol=tol/10)
     ψ₀ = gs["groundstate"]
@@ -60,7 +60,7 @@ E_norm = [-0.73923, -0.48432, 1.76080]
 
 @testset "Dependence on filling" for i in eachindex(P)
     symm = SymmetryConfig(U1Irrep, U1Irrep, 2*Q[i], (P[i],Q[i]))
-    model = ModelParams(t, u)
+    model = HubbardParams(t, u)
     calc = CalcConfig(symm, model)
     gs = compute_groundstate(calc; tol=tol/10)
     ψ₀ = gs["groundstate"]
@@ -76,7 +76,7 @@ end
 ###############
 
 symm = SymmetryConfig(U1Irrep, Trivial, 2, (1,1))
-model = ModelParams([0.0, 1.0], [5.0])
+model = HubbardParams([0.0, 1.0], [5.0])
 calc = CalcConfig(symm, model)
 
 gs = compute_groundstate(calc; tol=tol/10)

--- a/test/StaggeredField.jl
+++ b/test/StaggeredField.jl
@@ -44,7 +44,7 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
         push!(E_list, E)
         
         # Step 4: Calculate new Ms
-        Ms_new = calc_ms(ψ, symm)
+        Ms_new = calc_ms(ψ, calc)
         Ms_change = abs(Ms_new - Ms)
         push!(Ms_list, Ms_new)
         

--- a/test/StaggeredField.jl
+++ b/test/StaggeredField.jl
@@ -6,7 +6,6 @@ println("
 
 tol = 2e-1
 
-
 # Symmetries
 particle_symmetry = U1Irrep
 spin_symmetry = U1Irrep
@@ -30,8 +29,8 @@ function run_self_consistent_ms(symm::SymmetryConfig, t::Vector{Float64},
 
     for i in 1:max_iter
         # Step 2: Set up model parameters with current Ms
-        model = ModelParams(t, U; J_M0=(J_inter, Ms))
-        calc = CalcConfig(symm, model)
+        model = HubbardParams(t, U)
+        calc = CalcConfig(symm, model, StaggeredField(J_inter, Ms))
 
         # Step 3: Compute the ground state
         gs = compute_groundstate(calc; svalue = svalue, init_state=ψ_init)

--- a/test/ThreeBody.jl
+++ b/test/ThreeBody.jl
@@ -18,7 +18,7 @@ E_norm = -0.32384
     t = [0.0, 1.0]
     U = [6.0]
     V = [2.0]
-    model = HubbardParams(t, U, V)
+    model = HubbardParams(t, U)
     calc = CalcConfig(symm, model, ThreeBodyTerm(V))
     gs = compute_groundstate(calc; tol=tol/10)
     ψ₀ = gs["groundstate"]

--- a/test/ThreeBody.jl
+++ b/test/ThreeBody.jl
@@ -18,8 +18,8 @@ E_norm = -0.32384
     t = [0.0, 1.0]
     U = [6.0]
     V = [2.0]
-    model = ModelParams(t, U, V)
-    calc = CalcConfig(symm, model)
+    model = HubbardParams(t, U, V)
+    calc = CalcConfig(symm, model, ThreeBodyTerm(V))
     gs = compute_groundstate(calc; tol=tol/10)
     ψ₀ = gs["groundstate"]
     H = gs["ham"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,8 @@ ti = time()
     if GROUP == "ALL" || GROUP == "STAGGEREDFIELD"
         @time include("StaggeredField.jl")
     end
-    if GROUP == "ALL" || GROUP == "HUBBARDHOLSTEIN"
-        @time include("HubbardHolstein.jl")
+    if GROUP == "ALL" || GROUP == "HOLSTEIN"
+        @time include("Holstein.jl")
     end
 end
 


### PR DESCRIPTION
This PR rewrites the fundamental CalcConfig structure. Instead of the ModelParams structure, the Hubbard parameters are now stored in a HubbardParams, while additional terms (three-body interactions, (staggered) magnetic field, and Holstein terms) can be passed as HamiltonianTerms.

Additionally, the Hubbard-Holstein model is now also implemented for multi-band systems and symmetries other than Trivial x U1.